### PR TITLE
Add module and memory settings to Agent Builder

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -8,6 +8,7 @@ const hotelRoutes = require('./server/hotels.cjs');
 const userRoutes = require('./server/users.cjs');
 const analyticsRoutes = require('./server/analytics.cjs');
 const supportRoutes = require('./server/support.cjs');
+const interactionsRoutes = require('./server/interactions.cjs');
 const planRoutes = require('./server/plans.cjs');
 const languageRoutes = require('./server/languages.cjs');
 const chatbotRoutes = require('./server/chatbot.cjs');
@@ -51,6 +52,7 @@ app.use('/api/settings', authMiddleware, settingsRoutes);
 app.use('/api/chatbot', chatbotRoutes);
 app.use('/api/clients', authMiddleware, clientsRoutes);
 app.use('/api/agents', authMiddleware, agentRoutes);
+app.use('/api/interactions', authMiddleware, interactionsRoutes);
 // Upload routes integrated directly
 
 // Health check endpoint

--- a/server/agents.cjs
+++ b/server/agents.cjs
@@ -2,6 +2,27 @@ const express = require('express');
 const router = express.Router();
 const db = require('./db.cjs');
 
+// List versions for an agent. Superadmin can specify hotel_id query.
+router.get('/versions', async (req, res) => {
+  const hotelId =
+    req.user.role === 'superadmin'
+      ? req.query.hotel_id || req.user.hotel_id
+      : req.user.hotel_id;
+  try {
+    const { rows } = await db.query(
+      `SELECT id, created_at FROM agent_versions
+       WHERE agent_id = $1
+       ORDER BY created_at DESC
+       LIMIT 20`,
+      [hotelId]
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('Failed to fetch agent versions:', err);
+    res.status(500).json({ error: 'Failed to fetch agent versions' });
+  }
+});
+
 // Fetch agent config. Superadmins can specify ?hotel_id=XXX
 router.get('/', async (req, res) => {
   const hotelId =
@@ -42,12 +63,20 @@ router.post('/', async (req, res) => {
          WHERE hotel_id=$8 RETURNING *`,
         [name, persona, language, greeting, flow, modules, memory_vars, hotelId]
       );
+      await db.query(
+        'INSERT INTO agent_versions (agent_id, flow) VALUES ($1,$2)',
+        [hotelId, flow]
+      );
       return res.json(result.rows[0]);
     }
     const insert = await db.query(
       `INSERT INTO agents (hotel_id, name, persona, language, greeting, flow, modules, memory_vars)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *`,
       [hotelId, name, persona, language, greeting, flow, modules, memory_vars]
+    );
+    await db.query(
+      'INSERT INTO agent_versions (agent_id, flow) VALUES ($1,$2)',
+      [hotelId, flow]
     );
     res.json(insert.rows[0]);
   } catch (err) {

--- a/server/agents.cjs
+++ b/server/agents.cjs
@@ -29,7 +29,7 @@ router.post('/', async (req, res) => {
     req.user.role === 'superadmin'
       ? req.query.hotel_id || req.body.hotel_id || req.user.hotel_id
       : req.user.hotel_id;
-  const { name, persona, language, greeting, flow } = req.body;
+  const { name, persona, language, greeting, flow, modules, memory_vars } = req.body;
   try {
     const { rows } = await db.query(
       'SELECT id FROM agents WHERE hotel_id = $1',
@@ -38,16 +38,16 @@ router.post('/', async (req, res) => {
     if (rows.length) {
       const result = await db.query(
         `UPDATE agents
-         SET name=$1, persona=$2, language=$3, greeting=$4, flow=$5, updated_at=NOW()
-         WHERE hotel_id=$6 RETURNING *`,
-        [name, persona, language, greeting, flow, hotelId]
+         SET name=$1, persona=$2, language=$3, greeting=$4, flow=$5, modules=$6, memory_vars=$7, updated_at=NOW()
+         WHERE hotel_id=$8 RETURNING *`,
+        [name, persona, language, greeting, flow, modules, memory_vars, hotelId]
       );
       return res.json(result.rows[0]);
     }
     const insert = await db.query(
-      `INSERT INTO agents (hotel_id, name, persona, language, greeting, flow)
-       VALUES ($1,$2,$3,$4,$5,$6) RETURNING *`,
-      [hotelId, name, persona, language, greeting, flow]
+      `INSERT INTO agents (hotel_id, name, persona, language, greeting, flow, modules, memory_vars)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *`,
+      [hotelId, name, persona, language, greeting, flow, modules, memory_vars]
     );
     res.json(insert.rows[0]);
   } catch (err) {

--- a/server/chatbot.cjs
+++ b/server/chatbot.cjs
@@ -53,6 +53,13 @@ router.get('/hotel/:slug', async (req, res) => {
               COALESCE(c.logo_url,h.logo_url) AS logo_url,
               COALESCE(c.default_language,h.default_lang_code) AS default_lang_code,
               c.menu_items,
+              h.description,
+              h.contact_name,
+              h.contact_email,
+              h.booking_link,
+              h.address,
+              h.phone,
+              h.email,
               COALESCE(json_agg(json_build_object('code', hl.lang_code,
                                           'name', l.name,
                                           'active', hl.is_active))

--- a/server/interactions.cjs
+++ b/server/interactions.cjs
@@ -1,0 +1,27 @@
+const express = require('express');
+const router = express.Router();
+const db = require('./db.cjs');
+
+// List interactions for current user's hotel. Superadmins can filter by ?hotel_id
+router.get('/', async (req, res) => {
+  const hotelId =
+    req.user.role === 'superadmin'
+      ? req.query.hotel_id || req.user.hotel_id
+      : req.user.hotel_id;
+  try {
+    const { rows } = await db.query(
+      `SELECT id, hotel_id, session_id, timestamp, lang_code, user_input, bot_response, intent_detected, confidence_score, feedback
+       FROM interactions
+       WHERE hotel_id = $1
+       ORDER BY timestamp DESC
+       LIMIT 100`,
+      [hotelId]
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('Failed to fetch interactions:', err);
+    res.status(500).json({ error: 'Failed to fetch interactions' });
+  }
+});
+
+module.exports = router;

--- a/server/seed.mjs
+++ b/server/seed.mjs
@@ -119,6 +119,8 @@ async function createTables() {
         language TEXT,
         greeting TEXT,
         flow JSONB,
+        modules JSONB,
+        memory_vars JSONB,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       );
@@ -199,6 +201,14 @@ async function seedDatabase() {
     ];
     for (const [c, d] of hotelCols) {
       await ensureColumn('hotels', c, d);
+    }
+
+    const agentCols = [
+      ['modules', 'JSONB'],
+      ['memory_vars', 'JSONB']
+    ];
+    for (const [c, d] of agentCols) {
+      await ensureColumn('agents', c, d);
     }
 
     const ticketCols = [
@@ -372,14 +382,16 @@ async function seedDatabase() {
       `);
 
       await db.query(`
-        INSERT INTO public.agents (hotel_id, name, persona, language, greeting, flow)
+        INSERT INTO public.agents (hotel_id, name, persona, language, greeting, flow, modules, memory_vars)
         VALUES (
           '550e8400-e29b-41d4-a716-446655440000',
           'Assistant Virtuel',
           'Vous êtes le réceptionniste virtuel du Demo Hotel.',
           'fr',
           'Bonjour et bienvenue au Demo Hotel !',
-          '{"start":{"id":"start","message":"Bonjour! Comment puis-je vous aider?","next":null}}'::jsonb
+          '{"start":{"id":"start","message":"Bonjour! Comment puis-je vous aider?","next":null}}'::jsonb,
+          '["weather","booking"]'::jsonb,
+          '["name","date"]'::jsonb
         )
         ON CONFLICT (hotel_id) DO NOTHING;
       `);

--- a/server/seed.mjs
+++ b/server/seed.mjs
@@ -125,6 +125,13 @@ async function createTables() {
         updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       );
 
+      CREATE TABLE IF NOT EXISTS public.agent_versions (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        agent_id UUID REFERENCES public.agents(hotel_id) ON DELETE CASCADE,
+        flow JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+
 
       CREATE TABLE IF NOT EXISTS public.support_tickets (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -291,6 +298,11 @@ async function seedDatabase() {
     `);
 
     await db.query(`
+      INSERT INTO public.agent_versions (agent_id, flow)
+      SELECT hotel_id, flow FROM public.agents WHERE hotel_id = '550e8400-e29b-41d4-a716-446655440000';
+    `);
+
+    await db.query(`
       UPDATE public.hotels
          SET slug = 'demo-hotel',
              contact_name = 'Demo Admin',
@@ -394,6 +406,10 @@ async function seedDatabase() {
           '["name","date"]'::jsonb
         )
         ON CONFLICT (hotel_id) DO NOTHING;
+      `);
+      await db.query(`
+        INSERT INTO public.agent_versions (agent_id, flow)
+        SELECT hotel_id, flow FROM public.agents WHERE hotel_id = '550e8400-e29b-41d4-a716-446655440000';
       `);
     }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ const SuperAdminDashboard = lazy(() => import('@/pages/SuperAdminDashboard.jsx')
 const ClientDashboard = lazy(() => import('@/pages/ClientDashboard.jsx'));
 const ChatbotInterface = lazy(() => import('@/pages/ChatbotInterface.jsx'));
 const LoginPage = lazy(() => import('@/pages/LoginPage.jsx'));
+const HotelInfoPage = lazy(() => import('@/pages/HotelInfoPage.jsx'));
 
 const LoadingFallback = () => (
   <div className="min-h-screen flex items-center justify-center bg-background">
@@ -78,15 +79,16 @@ function App() {
                   </ProtectedRoute>
                 } 
               />
-              <Route 
-                path="/client/*" 
+              <Route
+                path="/client/*"
                 element={
                   <ProtectedRoute allowedRoles={['admin', 'manager']}>
                     <ClientDashboard />
                   </ProtectedRoute>
-                } 
+                }
               />
               <Route path="/bot/:slug" element={<ChatbotInterface />} />
+              <Route path="/hotel/:slug" element={<HotelInfoPage />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </Suspense>

--- a/src/components/client/InteractionsView.jsx
+++ b/src/components/client/InteractionsView.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { useClientData } from '@/hooks/useClientData';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const ClientInteractionsView = () => {
+  const { interactions, fetchInteractions, loading } = useClientData();
+
+  useEffect(() => {
+    fetchInteractions();
+  }, []);
+
+  return (
+    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+      <div className="dashboard-card rounded-xl p-6">
+        <h2 className="text-xl font-bold mb-4 text-foreground">Logs des Interactions</h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left py-2 px-1">Date</th>
+                <th className="text-left py-2 px-1">Question</th>
+                <th className="text-left py-2 px-1">Réponse</th>
+                <th className="text-left py-2 px-1">Feedback</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading && (!interactions || interactions.length === 0) ? (
+                Array.from({ length: 5 }).map((_, i) => (
+                  <tr key={i} className="border-b border-border/50">
+                    <td className="py-3 px-1" colSpan={4}><Skeleton className="h-6 w-full" /></td>
+                  </tr>
+                ))
+              ) : interactions && interactions.length > 0 ? (
+                interactions.map(int => (
+                  <tr key={int.id} className="border-b border-border/50 hover:bg-secondary/50">
+                    <td className="py-2 px-1 text-muted-foreground">{new Date(int.timestamp).toLocaleString()}</td>
+                    <td className="py-2 px-1 text-foreground max-w-xs truncate" title={int.user_input}>{int.user_input}</td>
+                    <td className="py-2 px-1 text-foreground max-w-xs truncate" title={int.bot_response}>{int.bot_response}</td>
+                    <td className="py-2 px-1 text-center">{int.feedback ?? ''}</td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td className="text-center py-4 text-muted-foreground" colSpan={4}>Aucune interaction</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default ClientInteractionsView;
+

--- a/src/components/superadmin/AgentHistoryView.jsx
+++ b/src/components/superadmin/AgentHistoryView.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { useSuperAdminData } from '@/hooks/useSuperAdminData';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+
+const AgentHistoryView = () => {
+  const { allData, fetchAgentVersions } = useSuperAdminData();
+  const hotels = allData.hotels || [];
+  const [selectedHotel, setSelectedHotel] = useState(hotels[0]?.id || '');
+  const [versions, setVersions] = useState([]);
+
+  useEffect(() => {
+    if (selectedHotel) {
+      fetchAgentVersions(selectedHotel).then(setVersions).catch(() => {});
+    }
+  }, [selectedHotel]);
+
+  return (
+    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+      <div className="space-y-4">
+        <Select value={selectedHotel} onValueChange={setSelectedHotel}>
+          <SelectTrigger className="bg-secondary border-border w-60">
+            <SelectValue placeholder="Choisir un hôtel" />
+          </SelectTrigger>
+          <SelectContent>
+            {hotels.map(h => (
+              <SelectItem key={h.id} value={h.id}>{h.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border">
+              <th className="py-2 px-1 text-left">Date</th>
+              <th className="py-2 px-1 text-left">Version ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {versions.map(v => (
+              <tr key={v.id} className="border-b border-border/50">
+                <td className="py-2 px-1">{new Date(v.created_at).toLocaleString()}</td>
+                <td className="py-2 px-1 font-mono text-xs">{v.id}</td>
+              </tr>
+            ))}
+            {versions.length === 0 && (
+              <tr>
+                <td colSpan={2} className="py-4 text-center text-muted-foreground">Aucune version</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </motion.div>
+  );
+};
+
+export default AgentHistoryView;

--- a/src/components/superadmin/InteractionsView.jsx
+++ b/src/components/superadmin/InteractionsView.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { useSuperAdminData } from '@/hooks/useSuperAdminData';
+import { Skeleton } from '@/components/ui/skeleton';
+
+const InteractionsView = () => {
+  const { data: interactions, loading, fetchInteractions } = useSuperAdminData('interactions');
+
+  useEffect(() => {
+    fetchInteractions();
+  }, []);
+
+  return (
+    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+      <div className="dashboard-card rounded-xl p-6">
+        <h2 className="text-xl font-bold mb-4 text-foreground">Logs des Interactions</h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left py-2 px-1">Date</th>
+                <th className="text-left py-2 px-1">Question</th>
+                <th className="text-left py-2 px-1">Réponse</th>
+                <th className="text-left py-2 px-1">Feedback</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading && (!interactions || interactions.length === 0) ? (
+                Array.from({ length: 5 }).map((_, i) => (
+                  <tr key={i} className="border-b border-border/50">
+                    <td className="py-3 px-1" colSpan={4}><Skeleton className="h-6 w-full" /></td>
+                  </tr>
+                ))
+              ) : interactions && interactions.length > 0 ? (
+                interactions.map(int => (
+                  <tr key={int.id} className="border-b border-border/50 hover:bg-secondary/50">
+                    <td className="py-2 px-1 text-muted-foreground">{new Date(int.timestamp).toLocaleString()}</td>
+                    <td className="py-2 px-1 text-foreground max-w-xs truncate" title={int.user_input}>{int.user_input}</td>
+                    <td className="py-2 px-1 text-foreground max-w-xs truncate" title={int.bot_response}>{int.bot_response}</td>
+                    <td className="py-2 px-1 text-center">{int.feedback ?? ''}</td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td className="text-center py-4 text-muted-foreground" colSpan={4}>Aucune interaction</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default InteractionsView;

--- a/src/hooks/useClientData.js
+++ b/src/hooks/useClientData.js
@@ -8,6 +8,7 @@ export const useClientData = () => {
   const [supportTickets, setSupportTickets] = useState([]);
   const [knowledgeBase, setKnowledgeBase] = useState([]);
   const [agentConfig, setAgentConfig] = useState(null);
+  const [interactions, setInteractions] = useState([]);
   const [availableLanguages, setAvailableLanguages] = useState([]);
   const [hotelId, setHotelId] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -53,14 +54,21 @@ export const useClientData = () => {
           console.error('getAgentConfig failed:', err);
           return null;
         });
+      const interactionsPromise = apiService
+        .getInteractions()
+        .catch((err) => {
+          console.error('getInteractions failed:', err);
+          return [];
+        });
 
-      const [hotelData, analyticsData, customizationData, ticketsData, knowledgeData, agentData] = await Promise.all([
+      const [hotelData, analyticsData, customizationData, ticketsData, knowledgeData, agentData, interactionsData] = await Promise.all([
         hotelPromise,
         analyticsPromise,
         customizationPromise,
         ticketsPromise,
         knowledgePromise,
         agentPromise,
+        interactionsPromise,
       ]);
 
       if (hotelData) {
@@ -97,6 +105,7 @@ export const useClientData = () => {
       setAnalytics(analyticsData || {});
       setSupportTickets(ticketsData || []);
       setKnowledgeBase(knowledgeData || []);
+      setInteractions(interactionsData || []);
       if (agentData) setAgentConfig(agentData);
     } catch (err) {
       setError(err.message);
@@ -219,6 +228,16 @@ export const useClientData = () => {
     return saved;
   };
 
+  const fetchInteractions = async () => {
+    try {
+      const data = await apiService.getInteractions();
+      setInteractions(data);
+      return data;
+    } catch (err) {
+      throw err;
+    }
+  };
+
   return {
     profile,
     customization,
@@ -238,6 +257,8 @@ export const useClientData = () => {
     deleteKnowledgeItem,
     agentConfig,
     saveAgentConfig,
+    interactions,
+    fetchInteractions,
     refetch: fetchData
   };
 };

--- a/src/hooks/useSuperAdminData.js
+++ b/src/hooks/useSuperAdminData.js
@@ -7,6 +7,7 @@ export const useSuperAdminData = (resource) => {
   const [users, setUsers] = useState([]);
   const [plans, setPlans] = useState([]);
   const [supportTickets, setSupportTickets] = useState([]);
+  const [interactions, setInteractions] = useState([]);
   const [dashboard, setDashboard] = useState(null);
   const [agentConfig, setAgentConfig] = useState(null);
   const [analytics, setAnalytics] = useState({
@@ -24,13 +25,14 @@ export const useSuperAdminData = (resource) => {
   const fetchData = async () => {
     try {
       setLoading(true);
-      const [clientsData, hotelsData, usersData, plansData, ticketsData, analyticsData] = await Promise.all([
+      const [clientsData, hotelsData, usersData, plansData, ticketsData, analyticsData, interactionsData] = await Promise.all([
         apiService.getClients(),
         apiService.getHotels(),
         apiService.getUsers(),
         apiService.getPlans(),
         apiService.getSupportTickets(),
-        apiService.getAnalytics()
+        apiService.getAnalytics(),
+        apiService.getInteractions()
       ]);
 
       setClients(clientsData);
@@ -38,6 +40,7 @@ export const useSuperAdminData = (resource) => {
       setUsers(usersData);
       setPlans(plansData);
       setSupportTickets(ticketsData);
+      setInteractions(interactionsData);
       setAnalytics({
         stats: analyticsData.stats || {},
         conversationsData: analyticsData.conversationsData || [],
@@ -191,12 +194,23 @@ export const useSuperAdminData = (resource) => {
     }
   };
 
+  const fetchInteractions = async (hotelId) => {
+    try {
+      const data = await apiService.getInteractions(hotelId);
+      setInteractions(data);
+      return data;
+    } catch (err) {
+      throw err;
+    }
+  };
+
   const dataMap = {
     clients,
     hotels,
     users,
     plans,
     supportTickets,
+    interactions,
     analytics,
     dashboard,
     agentConfig,
@@ -207,13 +221,14 @@ export const useSuperAdminData = (resource) => {
     users: setUsers,
     plans: setPlans,
     supportTickets: setSupportTickets,
+    interactions: setInteractions,
     analytics: setAnalytics,
     dashboard: setDashboard,
   };
 
   return {
     data: dataMap[resource] || null,
-    allData: { clients, hotels, users, plans, supportTickets, analytics, dashboard },
+    allData: { clients, hotels, users, plans, supportTickets, interactions, analytics, dashboard },
     loading,
     error,
     addHotel: createHotel,
@@ -229,6 +244,7 @@ export const useSuperAdminData = (resource) => {
     saveAgentConfig,
     fetchAISettings,
     saveAISettings,
+    fetchInteractions,
     refetch: fetchData,
     setData: setterMap[resource],
   };

--- a/src/hooks/useSuperAdminData.js
+++ b/src/hooks/useSuperAdminData.js
@@ -204,6 +204,14 @@ export const useSuperAdminData = (resource) => {
     }
   };
 
+  const fetchAgentVersions = async (hotelId) => {
+    try {
+      return await apiService.getAgentVersions(hotelId);
+    } catch (err) {
+      throw err;
+    }
+  };
+
   const dataMap = {
     clients,
     hotels,
@@ -245,6 +253,7 @@ export const useSuperAdminData = (resource) => {
     fetchAISettings,
     saveAISettings,
     fetchInteractions,
+    fetchAgentVersions,
     refetch: fetchData,
     setData: setterMap[resource],
   };

--- a/src/pages/ClientDashboard.jsx
+++ b/src/pages/ClientDashboard.jsx
@@ -17,6 +17,7 @@ import {
   LayoutDashboard,
   Bell,
   Menu,
+  List,
   Languages as LanguagesIcon,
   LifeBuoy
 } from 'lucide-react';
@@ -29,6 +30,7 @@ const SettingsView = lazy(() => import('@/components/client/SettingsView'));
 const LanguagesView = lazy(() => import('@/components/client/LanguagesView'));
 const SupportView = lazy(() => import('@/components/client/SupportView'));
 const AgentBuilderView = lazy(() => import('@/components/client/AgentBuilderView'));
+const ClientInteractionsView = lazy(() => import('@/components/client/InteractionsView'));
 
 const LoadingViewFallback = () => (
   <div className="min-h-[calc(100vh-10rem)] flex items-center justify-center">
@@ -45,7 +47,7 @@ const ClientDashboard = () => {
 
   const getActiveTab = () => {
     const path = location.pathname.split('/').pop();
-    if (['customize', 'analytics', 'qr-code', 'settings', 'documentation', 'languages', 'support', 'builder'].includes(path)) {
+    if (['customize', 'analytics', 'qr-code', 'settings', 'documentation', 'languages', 'support', 'builder', 'interactions'].includes(path)) {
       return path;
     }
     return 'dashboard';
@@ -96,6 +98,7 @@ const ClientDashboard = () => {
           { id: 'builder', icon: Bot, label: 'Agent Builder', path: '/client/builder' },
           { id: 'languages', icon: LanguagesIcon, label: 'Langues', path: '/client/languages' },
           { id: 'analytics', icon: BarChart3, label: 'Analytics', path: '/client/analytics' },
+          { id: 'interactions', icon: List, label: 'Logs', path: '/client/interactions' },
           { id: 'qr-code', icon: QrCode, label: 'QR Code & Lien', path: '/client/qr-code' },
           { id: 'settings', icon: Settings, label: 'Paramètres & Compte', path: '/client/settings' },
           { id: 'support', icon: LifeBuoy, label: 'Support', path: '/client/support' },
@@ -172,6 +175,7 @@ const ClientDashboard = () => {
               <Route path="languages" element={<LanguagesView />} />
               <Route path="qr-code" element={<QRCodeView />} />
               <Route path="analytics" element={<AnalyticsView />} />
+              <Route path="interactions" element={<ClientInteractionsView />} />
               <Route path="support" element={<SupportView />} />
               <Route path="settings" element={<SettingsView />} />
               <Route path="documentation" element={<DocumentationView />} />

--- a/src/pages/HotelInfoPage.jsx
+++ b/src/pages/HotelInfoPage.jsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchHotelConfigBySlug } from '@/services/chatbotService';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Bot } from 'lucide-react';
+
+const HotelInfoPage = () => {
+  const { slug } = useParams();
+  const [hotel, setHotel] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchHotelConfigBySlug(slug);
+        setHotel(data);
+      } catch (err) {
+        console.error('Failed to load hotel info', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [slug]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Skeleton className="h-64 w-64" />
+      </div>
+    );
+  }
+
+  if (!hotel) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-foreground">Hôtel introuvable.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="p-6 bg-primary text-primary-foreground">
+        <div className="container mx-auto flex items-center space-x-4">
+          {hotel.logo_url ? (
+            <img src={hotel.logo_url} alt="Logo" className="h-12 w-12 object-contain" />
+          ) : (
+            <Bot className="h-10 w-10" />
+          )}
+          <h1 className="text-2xl font-bold">{hotel.name}</h1>
+        </div>
+      </header>
+      <main className="container mx-auto p-6 space-y-6">
+        {hotel.description && <p>{hotel.description}</p>}
+        {Array.isArray(hotel.menu_items) && hotel.menu_items.length > 0 && (
+          <nav className="space-y-2">
+            {hotel.menu_items.map((item, idx) => (
+              <a
+                key={idx}
+                href={item.url}
+                className="block text-primary underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {item.label}
+              </a>
+            ))}
+          </nav>
+        )}
+        <div className="space-y-1">
+          {hotel.address && <p>Adresse: {hotel.address}</p>}
+          {hotel.phone && <p>Téléphone: {hotel.phone}</p>}
+          {hotel.email && <p>Email: {hotel.email}</p>}
+          {hotel.booking_link && (
+            <a
+              href={hotel.booking_link}
+              className="text-primary underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Réserver
+            </a>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default HotelInfoPage;

--- a/src/pages/SuperAdminDashboard.jsx
+++ b/src/pages/SuperAdminDashboard.jsx
@@ -19,7 +19,7 @@ import {
   Settings as SettingsIcon,
   LifeBuoy,
   Menu,
-  Bot
+  Bot,
   List,
   History
 } from 'lucide-react';

--- a/src/pages/SuperAdminDashboard.jsx
+++ b/src/pages/SuperAdminDashboard.jsx
@@ -20,7 +20,8 @@ import {
   LifeBuoy,
   Menu,
   Bot
-  List
+  List,
+  History
 } from 'lucide-react';
 
 const SuperAdminDashboardView = lazy(() => import('@/components/superadmin/SuperAdminDashboardView'));
@@ -32,6 +33,7 @@ const SuperAdminBillingView = lazy(() => import('@/components/superadmin/Billing
 const SuperAdminSettingsView = lazy(() => import('@/components/superadmin/SettingsView'));
 const SupportTicketsView = lazy(() => import('@/components/superadmin/SupportTicketsView'));
 const InteractionsView = lazy(() => import('@/components/superadmin/InteractionsView'));
+const AgentHistoryView = lazy(() => import('@/components/superadmin/AgentHistoryView'));
 
 const LoadingViewFallback = () => (
   <div className="min-h-[calc(100vh-10rem)] flex items-center justify-center">
@@ -66,7 +68,7 @@ const SuperAdminDashboard = () => {
 
   const getActiveTab = () => {
     const path = location.pathname.split('/').pop();
-    if (['clients', 'agent-builder', 'analytics', 'billing', 'system', 'settings', 'support-tickets', 'interactions'].includes(path)) {
+    if (['clients', 'agent-builder', 'analytics', 'billing', 'system', 'settings', 'support-tickets', 'interactions', 'agent-history'].includes(path)) {
       return path;
     }
     return 'dashboard';
@@ -111,6 +113,7 @@ const SuperAdminDashboard = () => {
           { id: 'agent-builder', icon: Bot, label: 'Agent Builder', path: '/superadmin/agent-builder' },
           { id: 'support-tickets', icon: LifeBuoy, label: 'Support Tickets', path: '/superadmin/support-tickets', badge: notifications > 0 ? notifications : null },
           { id: 'interactions', icon: List, label: 'Logs', path: '/superadmin/interactions' },
+          { id: 'agent-history', icon: History, label: 'Historique', path: '/superadmin/agent-history' },
           { id: 'analytics', icon: BarChart3, label: 'Analytics', path: '/superadmin/analytics' },
           { id: 'billing', icon: CreditCard, label: 'Facturation', path: '/superadmin/billing' },
           { id: 'system', icon: Server, label: 'Système IA', path: '/superadmin/system' },
@@ -219,6 +222,7 @@ const SuperAdminDashboard = () => {
                 <Route path="agent-builder" element={<AgentFlowEditor />} />
                 <Route path="support-tickets" element={<SupportTicketsView />} />
                 <Route path="interactions" element={<InteractionsView />} />
+                <Route path="agent-history" element={<AgentHistoryView />} />
                 <Route path="system" element={<SystemView />} />
                 <Route path="analytics" element={<SuperAdminAnalyticsView />} />
               <Route path="billing" element={<SuperAdminBillingView />} />

--- a/src/pages/SuperAdminDashboard.jsx
+++ b/src/pages/SuperAdminDashboard.jsx
@@ -20,6 +20,7 @@ import {
   LifeBuoy,
   Menu,
   Bot
+  List
 } from 'lucide-react';
 
 const SuperAdminDashboardView = lazy(() => import('@/components/superadmin/SuperAdminDashboardView'));
@@ -29,7 +30,8 @@ const SystemView = lazy(() => import('@/components/superadmin/SystemView'));
 const SuperAdminAnalyticsView = lazy(() => import('@/components/superadmin/AnalyticsView'));
 const SuperAdminBillingView = lazy(() => import('@/components/superadmin/BillingView'));
 const SuperAdminSettingsView = lazy(() => import('@/components/superadmin/SettingsView'));
-const SupportTicketsView = lazy(() => import('@/components/superadmin/SupportTicketsView')); 
+const SupportTicketsView = lazy(() => import('@/components/superadmin/SupportTicketsView'));
+const InteractionsView = lazy(() => import('@/components/superadmin/InteractionsView'));
 
 const LoadingViewFallback = () => (
   <div className="min-h-[calc(100vh-10rem)] flex items-center justify-center">
@@ -64,7 +66,7 @@ const SuperAdminDashboard = () => {
 
   const getActiveTab = () => {
     const path = location.pathname.split('/').pop();
-    if (['clients', 'agent-builder', 'analytics', 'billing', 'system', 'settings', 'support-tickets'].includes(path)) {
+    if (['clients', 'agent-builder', 'analytics', 'billing', 'system', 'settings', 'support-tickets', 'interactions'].includes(path)) {
       return path;
     }
     return 'dashboard';
@@ -108,6 +110,7 @@ const SuperAdminDashboard = () => {
           { id: 'clients', icon: Users, label: 'Hôtels & Utilisateurs', path: '/superadmin/clients' },
           { id: 'agent-builder', icon: Bot, label: 'Agent Builder', path: '/superadmin/agent-builder' },
           { id: 'support-tickets', icon: LifeBuoy, label: 'Support Tickets', path: '/superadmin/support-tickets', badge: notifications > 0 ? notifications : null },
+          { id: 'interactions', icon: List, label: 'Logs', path: '/superadmin/interactions' },
           { id: 'analytics', icon: BarChart3, label: 'Analytics', path: '/superadmin/analytics' },
           { id: 'billing', icon: CreditCard, label: 'Facturation', path: '/superadmin/billing' },
           { id: 'system', icon: Server, label: 'Système IA', path: '/superadmin/system' },
@@ -215,6 +218,7 @@ const SuperAdminDashboard = () => {
                 <Route path="clients" element={<ClientsView />} />
                 <Route path="agent-builder" element={<AgentFlowEditor />} />
                 <Route path="support-tickets" element={<SupportTicketsView />} />
+                <Route path="interactions" element={<InteractionsView />} />
                 <Route path="system" element={<SystemView />} />
                 <Route path="analytics" element={<SuperAdminAnalyticsView />} />
               <Route path="billing" element={<SuperAdminBillingView />} />

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -240,6 +240,11 @@ class ApiService {
       body: data
     });
   }
+
+  async getInteractions(hotelId) {
+    const url = hotelId ? `/interactions?hotel_id=${hotelId}` : '/interactions';
+    return this.request(url);
+  }
 }
 
 export default new ApiService();

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -241,6 +241,11 @@ class ApiService {
     });
   }
 
+  async getAgentVersions(hotelId) {
+    const url = hotelId ? `/agents/versions?hotel_id=${hotelId}` : '/agents/versions';
+    return this.request(url);
+  }
+
   async getInteractions(hotelId) {
     const url = hotelId ? `/interactions?hotel_id=${hotelId}` : '/interactions';
     return this.request(url);


### PR DESCRIPTION
## Summary
- extend `agents` table with `modules` and `memory_vars`
- ensure columns are created during seed
- store defaults for demo agent
- support `modules` and `memory_vars` in API
- update client Agent Builder form with checkboxes and variable field

## Testing
- `node server/seed.mjs` *(fails: ECONNREFUSED)*
- `node tests/apiRequestTest.js`

------
https://chatgpt.com/codex/tasks/task_e_6852dfcfc56c8333916de6ed7186034b